### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/templates/CRM/Emailamender/Page/EmailAmenderSettingsTable.tpl
+++ b/templates/CRM/Emailamender/Page/EmailAmenderSettingsTable.tpl
@@ -25,6 +25,6 @@
 </table>
 {if $hasEditPermission}
   <input class="add_new_correction" type="button" value="Add new correction" filter_id="{$filter_id}"></input>
-  <input class="save_correction_changes save_changes_button" type="button" value="{ts}Save changes{/ts}" style="display: none" filter_id="{$filter_id}"></input>
+  <input class="save_correction_changes save_changes_button" type="button" value="{ts escape='htmlattribute'}Save changes{/ts}" style="display: none" filter_id="{$filter_id}"></input>
 {/if}
 </div>

--- a/templates/CRM/Emailamender/Page/EquivalentsTable.tpl
+++ b/templates/CRM/Emailamender/Page/EquivalentsTable.tpl
@@ -45,6 +45,6 @@
 </table>
   {if $hasEditPermission}
     <input class="add_new_equivalent" type="button" value="Add new equivalent" filter_id="{$filter_id}"></input>
-    <input class="save_correction_changes save_changes_button" type="button" value="{ts}Save changes{/ts}" style="display: none" filter_id="{$filter_id}"></input>
+    <input class="save_correction_changes save_changes_button" type="button" value="{ts escape='htmlattribute'}Save changes{/ts}" style="display: none" filter_id="{$filter_id}"></input>
   {/if}
 </div>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.